### PR TITLE
Build test projects with other projects

### DIFF
--- a/TixFactory.MsBuildProjectGenerator/TixFactory.MsBuildProjectGenerator/Implementation/ProjectBuilder.cs
+++ b/TixFactory.MsBuildProjectGenerator/TixFactory.MsBuildProjectGenerator/Implementation/ProjectBuilder.cs
@@ -56,6 +56,7 @@ namespace TixFactory.MsBuildProjectGenerator
 					{
 						case ProjectType.Tests:
 							testProjects.Add(project);
+							buildProjects.Add(project);
 							break;
 						case ProjectType.ConsoleApplication:
 						case ProjectType.WebApplication:


### PR DESCRIPTION
This review is to include test assemblies when building all projects with the build target. This will allow test runs to not require their own build steps. And when making sure repositories compile, it will also make sure the tests compile.